### PR TITLE
Fix parallelFor for zero-thread pools

### DIFF
--- a/thread-pool.h
+++ b/thread-pool.h
@@ -181,6 +181,14 @@ public:
         if (start >= end)
             return;
         
+        // When no worker threads exist, simply execute sequentially
+        if (getThreadCount() == 0) {
+            for (IndexType i = start; i < end; ++i) {
+                func(i);
+            }
+            return;
+        }
+
         if (chunkSize == 0)
             chunkSize = (end - start + getThreadCount() - 1) / getThreadCount();
 


### PR DESCRIPTION
## Summary
- run sequentially in `parallelFor` when thread count is zero

## Testing
- `./thread_pool_test --gtest_filter=ThreadPoolTest.EnqueueSingleTaskReturnsCorrectValue`

------
https://chatgpt.com/codex/tasks/task_e_683f3d6b938883219b4052a8639868c0